### PR TITLE
Add release support for aarch64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         nif: ["2.15", "2.16", "2.17"]
         job:
           - { target: aarch64-apple-darwin, os: macos-15 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04 }
           - {
               target: arm-unknown-linux-gnueabihf,
               os: ubuntu-22.04,


### PR DESCRIPTION
Add support for aarch64-unknown-linux-gnu to allow local docker builds on arm macs