### PR TITLE
feat: add aarch64-unknown-linux-musl target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
               use-cross: true,
             }
           - {
+              target: aarch64-unknown-linux-musl,
+              os: ubuntu-22.04,
+              use-cross: true,
+            }
+          - {
               target: arm-unknown-linux-gnueabihf,
               os: ubuntu-22.04,
               use-cross: true,

--- a/lib/imprintor.ex
+++ b/lib/imprintor.ex
@@ -24,7 +24,8 @@ defmodule Imprintor do
       "aarch64-apple-darwin",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-linux-musl",
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl"
     ]
 
   @doc """


### PR DESCRIPTION
Used for compiling on Docker in macos with alpine.