### PR TITLE
Dev/support standard and bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A fast and efficient Elixir library for generating PDF documents from [Typst](ht
 - 📝 **Typst syntax** support for beautiful document formatting
 - 🧩 **Rich data support** - pass complex nested data structures
 - 📚 **PDF standard selection** - enforce standards like `a-3a`, `ua-1`, and `1.7`
+- 📎 **Tagged bytes support** - pass binary data for Typst APIs like `pdf.attach`
 
 ## Installation
 
@@ -134,6 +135,32 @@ config = Imprintor.Config.new(template, %{}, pdf_standard: "a-3a")
 Supported values are:
 `1.4`, `1.5`, `1.6`, `1.7`, `2.0`, `a-1a`, `a-1b`, `a-2a`, `a-2b`, `a-2u`, `a-3a`, `a-3b`, `a-3u`, `a-4`, `a-4e`, `a-4f`, `ua-1`.
 
+### Tagged Bytes for `pdf.attach`
+
+```elixir
+template = """
+#set document(date: datetime.today())
+
+#pdf.attach(
+  "factur-x.xml",
+  sys.inputs.elixir_data.factur_x_xml,
+  relationship: "alternative",
+  mime-type: "application/xml",
+  description: "Factur-X XML",
+)
+
+= Invoice
+"""
+
+data = %{
+  "factur_x_xml" => Imprintor.bytes("<xml>...</xml>")
+}
+
+config = Imprintor.Config.new(template, data, pdf_standard: "a-3a")
+{:ok, pdf_binary} = Imprintor.compile_to_pdf(config)
+```
+
+`Imprintor.bytes/1` returns the tagged tuple `{:bytes, binary}`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A fast and efficient Elixir library for generating PDF documents from [Typst](ht
 - 💾 **In-memory PDF generation** - returns PDF binary data
 - 📝 **Typst syntax** support for beautiful document formatting
 - 🧩 **Rich data support** - pass complex nested data structures
+- 📚 **PDF standard selection** - enforce standards like `a-3a`, `ua-1`, and `1.7`
 
 ## Installation
 
@@ -117,6 +118,22 @@ Imprintor uses Typst syntax for data access:
   - #order.product: \\$#order.total
 ]
 ```
+
+### PDF Standard Option
+
+```elixir
+template = """
+#set document(date: datetime.today())
+= Invoice
+"""
+
+config = Imprintor.Config.new(template, %{}, pdf_standard: "a-3a")
+{:ok, pdf_binary} = Imprintor.compile_to_pdf(config)
+```
+
+Supported values are:
+`1.4`, `1.5`, `1.6`, `1.7`, `2.0`, `a-1a`, `a-1b`, `a-2a`, `a-2b`, `a-2u`, `a-3a`, `a-3b`, `a-3u`, `a-4`, `a-4e`, `a-4f`, `ua-1`.
+
 
 ## License
 

--- a/lib/imprintor.ex
+++ b/lib/imprintor.ex
@@ -80,6 +80,19 @@ defmodule Imprintor do
     end
   end
 
+  @doc """
+  Wraps raw binary data to be consumed as Typst `bytes`.
+
+  This is useful for APIs like `pdf.attach` that expect a bytes value.
+
+  ## Examples
+
+      data = %{
+        "factur_x_xml" => Imprintor.bytes("<xml>...</xml>")
+      }
+  """
+  def bytes(binary) when is_binary(binary), do: {:bytes, binary}
+
   def typst_to_pdf(_config), do: :erlang.nif_error(:nif_not_loaded)
   def typst_to_pdf_file(_config, _output_path), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/imprintor/config.ex
+++ b/lib/imprintor/config.ex
@@ -12,6 +12,7 @@ defmodule Imprintor.Config do
   * `:extra_fonts` - A list of additional font files or paths to include
   * `:root_directory` - The root directory for resolving relative paths (defaults to ".")
   * `:data` - A map containing template data and variables for document generation
+  * `:pdf_standard` - Optional PDF standard string (e.g. `"a-3a"`, `"ua-1"`, `"1.7"`)
 
   ## Examples
 
@@ -31,7 +32,7 @@ defmodule Imprintor.Config do
       ])
   """
 
-  defstruct [:source_document, :extra_fonts, :root_directory, :data]
+  defstruct [:source_document, :extra_fonts, :root_directory, :data, :pdf_standard]
 
   @doc """
   Creates a new configuration struct.
@@ -46,6 +47,7 @@ defmodule Imprintor.Config do
 
   * `:extra_fonts` - List of additional font files to include (defaults to `[]`)
   * `:root_directory` - Root directory for resolving relative paths (defaults to `"."`)
+  * `:pdf_standard` - PDF standard to enforce (defaults to `nil` / Typst default)
 
   ## Returns
 
@@ -79,11 +81,14 @@ defmodule Imprintor.Config do
 
     root_directory = Keyword.get(opts, :root_directory, ".")
 
+    pdf_standard = Keyword.get(opts, :pdf_standard)
+
     %__MODULE__{
       source_document: source_document,
       extra_fonts: extra_fonts,
       root_directory: root_directory,
-      data: data
+      data: data,
+      pdf_standard: pdf_standard
     }
   end
 end

--- a/native/imprintor/src/lib.rs
+++ b/native/imprintor/src/lib.rs
@@ -210,6 +210,18 @@ fn typst_values_from_elxiir(term: Term) -> typst::foundations::Value {
             let typst_array: Array = list.into_iter().map(typst_values_from_elxiir).collect();
             Value::Array(typst_array)
         }
+        rustler::TermType::Tuple => {
+            let tuple: (Term, Term) = term.decode().unwrap();
+
+            if tuple.0.get_type() == rustler::TermType::Atom
+                && tuple.0.atom_to_string().is_ok_and(|atom| atom == "bytes")
+            {
+                let binary: binary::Binary = tuple.1.decode().unwrap();
+                Value::Bytes(Bytes::new(binary.to_vec()))
+            } else {
+                Value::None
+            }
+        }
         rustler::TermType::Map => {
             let map: HashMap<Term, Term> = term.decode().unwrap();
             let mut dict = Dict::new();

--- a/native/imprintor/src/lib.rs
+++ b/native/imprintor/src/lib.rs
@@ -13,7 +13,7 @@ use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt};
 use typst_kit::fonts::{FontSlot, Fonts};
-use typst_pdf::PdfOptions;
+use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
 /// A File that will be stored in the HashMap.
 #[derive(Clone, Debug)]
 struct FileEntry {
@@ -65,6 +65,7 @@ pub struct ImprintorConfig<'a> {
     extra_fonts: Option<Vec<String>>,
     data: Option<Term<'a>>,
     root_directory: String,
+    pdf_standard: Option<String>,
 }
 
 impl ImprintorNifWorld {
@@ -292,11 +293,12 @@ fn typst_to_pdf<'a>(
     env: rustler::Env<'a>,
     config: ImprintorConfig,
 ) -> Result<rustler::Binary<'a>, String> {
+    let pdf_options = build_pdf_options(config.pdf_standard.as_deref())?;
     let world = ImprintorNifWorld::new(config);
 
     match typst::compile(&world).output {
         Ok(document) => {
-            let pdf_bytes = typst_pdf::pdf(&document, &PdfOptions::default()).unwrap();
+            let pdf_bytes = typst_pdf::pdf(&document, &pdf_options).unwrap();
             let mut binary = rustler::OwnedBinary::new(pdf_bytes.len()).unwrap();
             binary.as_mut_slice().copy_from_slice(&pdf_bytes);
             Ok(binary.release(env))
@@ -314,11 +316,12 @@ fn typst_to_pdf<'a>(
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn typst_to_pdf_file<'a>(config: ImprintorConfig, output_path: String) -> Result<String, String> {
+    let pdf_options = build_pdf_options(config.pdf_standard.as_deref())?;
     let world = ImprintorNifWorld::new(config);
 
     match typst::compile(&world).output {
         Ok(document) => {
-            let pdf_bytes = typst_pdf::pdf(&document, &PdfOptions::default()).unwrap();
+            let pdf_bytes = typst_pdf::pdf(&document, &pdf_options).unwrap();
             match std::fs::write(&output_path, pdf_bytes) {
                 Ok(_) => Ok(output_path.into()),
                 Err(err) => Err(err.to_string().into()),
@@ -332,6 +335,53 @@ fn typst_to_pdf_file<'a>(config: ImprintorConfig, output_path: String) -> Result
                 .join(", ");
             Err(format!("Compilation failed: {}", error_msg))
         }
+    }
+}
+
+fn build_pdf_options(pdf_standard: Option<&str>) -> Result<PdfOptions<'static>, String> {
+    let mut options = PdfOptions::default();
+
+    if let Some(standard_value) = pdf_standard {
+        let standard = parse_pdf_standard(standard_value).ok_or_else(|| {
+            format!(
+                "Unsupported PDF standard '{}' . Supported values: {}",
+                standard_value,
+                SUPPORTED_PDF_STANDARDS.join(", ")
+            )
+        })?;
+
+        options.standards =
+            PdfStandards::new(&[standard]).map_err(|err| format!("Invalid PDF standard: {err}"))?;
+    }
+
+    Ok(options)
+}
+
+const SUPPORTED_PDF_STANDARDS: [&str; 17] = [
+    "1.4", "1.5", "1.6", "1.7", "2.0", "a-1a", "a-1b", "a-2a", "a-2b", "a-2u", "a-3a", "a-3b",
+    "a-3u", "a-4", "a-4e", "a-4f", "ua-1",
+];
+
+fn parse_pdf_standard(input: &str) -> Option<PdfStandard> {
+    match input.trim().to_ascii_lowercase().as_str() {
+        "1.4" => Some(PdfStandard::V_1_4),
+        "1.5" => Some(PdfStandard::V_1_5),
+        "1.6" => Some(PdfStandard::V_1_6),
+        "1.7" => Some(PdfStandard::V_1_7),
+        "2.0" => Some(PdfStandard::V_2_0),
+        "a-1a" => Some(PdfStandard::A_1a),
+        "a-1b" => Some(PdfStandard::A_1b),
+        "a-2a" => Some(PdfStandard::A_2a),
+        "a-2b" => Some(PdfStandard::A_2b),
+        "a-2u" => Some(PdfStandard::A_2u),
+        "a-3a" => Some(PdfStandard::A_3a),
+        "a-3b" => Some(PdfStandard::A_3b),
+        "a-3u" => Some(PdfStandard::A_3u),
+        "a-4" => Some(PdfStandard::A_4),
+        "a-4e" => Some(PdfStandard::A_4e),
+        "a-4f" => Some(PdfStandard::A_4f),
+        "ua-1" => Some(PdfStandard::Ua_1),
+        _ => None,
     }
 }
 

--- a/test/imprintor_test.exs
+++ b/test/imprintor_test.exs
@@ -325,6 +325,47 @@ defmodule ImprintorTest do
     end
   end
 
+  test "compile_to_pdf with configured pdf standard" do
+    template = """
+    #set document(date: datetime.today())
+
+    = PDF Standard Test
+
+    This document should compile with an explicit PDF standard.
+    """
+
+    config = Imprintor.Config.new(template, %{}, pdf_standard: "1.7")
+
+    case Imprintor.compile_to_pdf(config) do
+      {:ok, pdf_binary} ->
+        assert is_binary(pdf_binary)
+        assert byte_size(pdf_binary) > 0
+        assert String.starts_with?(pdf_binary, "%PDF")
+
+      {:error, reason} ->
+        flunk(
+          "Expected successful PDF generation with pdf_standard, got error: #{inspect(reason)}"
+        )
+    end
+  end
+
+  test "compile_to_pdf with invalid pdf standard returns error" do
+    template = "= Invalid PDF Standard"
+    config = Imprintor.Config.new(template, %{}, pdf_standard: "not-a-real-standard")
+
+    case Imprintor.compile_to_pdf(config) do
+      {:ok, _pdf_binary} ->
+        flunk("Expected error for invalid pdf_standard, but compilation succeeded")
+
+      {:error, reason} ->
+        assert inspect(reason) =~ "Unsupported PDF standard"
+
+      error ->
+        flunk("Expected error tuple for invalid pdf_standard, got: #{inspect(error)}")
+    end
+  end
+
+
   test "compile_to_pdf with large file - 500 items with images and QR codes" do
     template = """
     #let qr = plugin("test/typst_plugin_qr.wasm")

--- a/test/imprintor_test.exs
+++ b/test/imprintor_test.exs
@@ -365,6 +365,39 @@ defmodule ImprintorTest do
     end
   end
 
+  test "compile_to_pdf supports tagged bytes tuple for pdf.attach" do
+    template = """
+    #set document(date: datetime.today())
+
+    #pdf.attach(
+      "factur-x.xml",
+      sys.inputs.elixir_data.factur_x_xml,
+      relationship: "alternative",
+      mime-type: "application/xml",
+      description: "Factur-X XML",
+    )
+
+    = Invoice Attachment Test
+    """
+
+    data = %{
+      "factur_x_xml" => Imprintor.bytes("<factur-x><id>123</id></factur-x>")
+    }
+
+    config = Imprintor.Config.new(template, data, pdf_standard: "a-3a")
+
+    case Imprintor.compile_to_pdf(config) do
+      {:ok, pdf_binary} ->
+        assert is_binary(pdf_binary)
+        assert byte_size(pdf_binary) > 0
+        assert String.starts_with?(pdf_binary, "%PDF")
+
+      {:error, reason} ->
+        flunk(
+          "Expected successful PDF generation with tagged bytes, got error: #{inspect(reason)}"
+        )
+    end
+  end
 
   test "compile_to_pdf with large file - 500 items with images and QR codes" do
     template = """


### PR DESCRIPTION
@andreh11 I've created an updated version 

With the main improvements being:

1. Allowing a PDF Standard to be passed
2. Allowing bytes to be specified explicitly using  `Imprintor.bytes/1`, which produces a tagged tuple that can then be understood on the rust side.



I've generated the file below using the approach:

```elixir
xml =
  ~s(<?xml version="1.0" encoding="UTF-8"?><factur-x><id>INV-PR-2026-0001</id><total>199.95</total></factur-x>)

note =
  """
  Attached by Imprintor PR sample
  Generated: 2026-04-12
  """

template = """
#set document(date: datetime.today())

#pdf.attach(
  "factur-x.xml",
  sys.inputs.elixir_data.factur_x_xml,
  relationship: "alternative",
  mime-type: "application/xml",
  description: "Factur-X XML",
)

#pdf.attach(
  "attachment-note.txt",
  sys.inputs.elixir_data.note_txt,
  relationship: "supplement",
  mime-type: "text/plain",
  description: "Sample attachment note",
)

= Imprintor Attachment Demo

This PDF contains embedded attachments for PR verification.

- XML bytes: #sys.inputs.elixir_data.xml_size
- TXT bytes: #sys.inputs.elixir_data.note_size
"""

data = %{
  "factur_x_xml" => Imprintor.bytes(xml),
  "note_txt" => Imprintor.bytes(note),
  "xml_size" => byte_size(xml),
  "note_size" => byte_size(note)
}

config = Imprintor.Config.new(template, data, pdf_standard: "a-3a")

case Imprintor.compile_to_pdf(config) do
  {:ok, pdf_binary} ->
    File.write!(@output_path, pdf_binary)
    {:ok, @output_path, byte_size(pdf_binary)}

  {:error, reason} ->
    {:error, reason}
end
```

I'm not super familiar with PDF attachments and how they should look (plus OSX doesn't seem to render file attachments in the Preview app), so would be good for you to check if this is what you need.

[pr_pdf_with_attachments.pdf](https://github.com/user-attachments/files/26650183/pr_pdf_with_attachments.pdf)
